### PR TITLE
Fix: TypeError: items.start.getUTCHours is not a function

### DIFF
--- a/6-scheduler-bot/src/step-2/index.js
+++ b/6-scheduler-bot/src/step-2/index.js
@@ -10,7 +10,7 @@ module.exports = function (context, req) {
                 end: items['end'].toLocaleTimeString('en-US', { hour12: false })
             });
             context.log(items['start']);
-            context.log(items['start'].getUTCHours());
+            context.log(new Date(items['start']).getUTCHours());
         })
     });
 

--- a/6-scheduler-bot/src/step-2/index.snippet.js
+++ b/6-scheduler-bot/src/step-2/index.snippet.js
@@ -8,6 +8,6 @@ req.body.forEach(function (calendar) {
             end: items['end'].toLocaleTimeString('en-US', { hour12: false })
         });
         context.log(items['start']);
-        context.log(items['start'].getUTCHours());
+        context.log(new Date(items['start']).getUTCHours());
     })
 });


### PR DESCRIPTION
## Purpose
This pull request fix the problem of the module 6. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

Follow the instruction of the module 6. 
At the step 2 when you post the request, you will see this error. 

```
[10/25/17 2:18:41 AM] A ScriptHost error has occurred
[10/25/17 2:18:41 AM] Exception while executing function: Functions.SchedulerBot. System.Private.CoreLib: Result: 
[10/25/17 2:18:41 AM] Exception: TypeError: items.start.getUTCHours is not a function
[10/25/17 2:18:41 AM] Stack: TypeError: items.start.getUTCHours is not a function
[10/25/17 2:18:41 AM]     at /Users/ushio/Codes/AzureFunctions/squirebot/squirebot/src/tasks-functions/SchedulerBot/index.js:14:34
[10/25/17 2:18:41 AM]     at Array.forEach (<anonymous>)
[10/25/17 2:18:41 AM]     at /Users/ushio/Codes/AzureFunctions/squirebot/squirebot/src/tasks-functions/SchedulerBot/index.js:7:24
[10/25/17 2:18:41 AM]     at Array.forEach (<anonymous>)
[10/25/17 2:18:41 AM]     at module.exports (/Users/ushio/Codes/AzureFunctions/squirebot/squirebot/src/tasks-functions/SchedulerBot/index.js:6:14)
[10/25/17 2:18:41 AM]     at WorkerChannel.invocationRequest (/Users/ushio/.azure
```
This error caused b because this code 

```
context.log(items['start'].getUTCHours());
```
item['start'] is not Date type. You need to convert it. 

* Test the code

Same as above. Module 6 step 2. 
